### PR TITLE
6588 support preferred mail

### DIFF
--- a/heron_wsgi/admin_lib/heron_policy.py
+++ b/heron_wsgi/admin_lib/heron_policy.py
@@ -201,6 +201,10 @@ This student's sponsor is not with KUMC anymore
   INFO:cache_remote:LDAP query for (u'(cn=prof.fickle)', ('cn', 'givenname',
        'kumcPersonFaculty', 'kumcPersonJobcode', 'mail', 'ou', 'sn', 'title'))
   INFO:cache_remote:... cached until 2011-09-02 00:00:08
+  INFO:cache_remote:LDAP query for (u'(mail=prof.fickle@kumc.edu)',
+    ('cn', 'givenname', 'kumcPersonFaculty', 'kumcPersonJobcode', 'mail', 'ou',
+     'sn', 'title'))
+  INFO:cache_remote:... cached until 2011-09-02 00:00:08.500000
   WARNING:heron_policy:Sponsor prof.fickle not at med center anymore.
   INFO:heron_policy:not sponsored: jill.student
   INFO:cache_remote:... cached until 2011-09-02 00:00:07.500000

--- a/heron_wsgi/admin_lib/heron_policy.py
+++ b/heron_wsgi/admin_lib/heron_policy.py
@@ -220,7 +220,7 @@ Ensure things don't go wonky in case of missing email address
   ... # doctest: +NORMALIZE_WHITESPACE
     INFO:cache_remote:LDAP query for ('(cn=todd.ryan)', ('cn', 'givenname',
        'kumcPersonFaculty', 'kumcPersonJobcode', 'mail', 'ou', 'sn', 'title'))
-    INFO:cache_remote:... cached until 2011-09-02 00:00:08.500000
+    INFO:cache_remote:... cached until 2011-09-02 00:00:09
     WARNING:medcenter:missing LDAP attribute mail for todd.ryan
     INFO:cache_remote:system access query for ('SAA', 'todd.ryan@js.example')
     INFO:cache_remote:... cached until 2011-09-02 00:00:22.500000
@@ -248,7 +248,7 @@ Executives don't need sponsorship::
   ... # doctest: +NORMALIZE_WHITESPACE
   INFO:cache_remote:LDAP query for ('(cn=big.wig)', ('cn', 'givenname',
        'kumcPersonFaculty', 'kumcPersonJobcode', 'mail', 'ou', 'sn', 'title'))
-  INFO:cache_remote:... cached until 2011-09-02 00:00:09
+  INFO:cache_remote:... cached until 2011-09-02 00:00:09.500000
   INFO:cache_remote:system access query for ('SAA', 'big.wig@js.example')
   INFO:cache_remote:... cached until 2011-09-02 00:00:23
   INFO:cache_remote:in DROC? query for big.wig
@@ -265,7 +265,7 @@ the oversight committee::
   ... # doctest: +NORMALIZE_WHITESPACE
   INFO:cache_remote:LDAP query for ('(cn=john.smith)', ('cn', 'givenname',
        'kumcPersonFaculty', 'kumcPersonJobcode', 'mail', 'ou', 'sn', 'title'))
-  INFO:cache_remote:... cached until 2011-09-02 00:00:09.500000
+  INFO:cache_remote:... cached until 2011-09-02 00:00:10
   >>> facreq.context.oversight_request
   OversightRequest(from=john.smith)
 

--- a/heron_wsgi/admin_lib/medcenter.py
+++ b/heron_wsgi/admin_lib/medcenter.py
@@ -40,6 +40,19 @@ A :class:`MedCenter` issues :class:`IDBadge` capabilities::
    False
 
 
+allow lookup by updated kumc mail alias
+---------------------------------------
+
+  >>> r3 = MockRequest()
+  >>> caps = m.authenticated('j12s34', r3)
+  >>> caps
+  [<MedCenter sealed box>]
+  >>> m.grant(r3.context, PERM_BROWSER)
+
+  >>> j_badge = m.idbadge(r3.context)
+  >>> j_badge.full_name()
+  'james smith'
+
 Human Subjects Training
 -----------------------
 
@@ -153,10 +166,12 @@ class Browser(object):
         matches = self._svc.search_cn(name, Badge.attributes)
 
         if len(matches) != 1:  # pragma nocover
-            if len(matches) == 0:
-                raise KeyError(name)
-            else:
-                raise ValueError(name)  # ambiguous
+            matches = self._svc.search_mail(name, Badge.attributes)
+            if len(matches) != 1:
+                if len(matches) == 0:
+                    raise KeyError(name)
+                else:
+                    raise ValueError(name)  # ambiguous
 
         dn, ldapattrs = matches[0]
         return LDAPBadge._simplify(ldapattrs)

--- a/heron_wsgi/admin_lib/medcenter.py
+++ b/heron_wsgi/admin_lib/medcenter.py
@@ -80,11 +80,6 @@ Part of making oversight requests is nominating team members::
 
   >>> r1.context.browser.search(5, 'john.smith', '', '')
   [John Smith <john.smith@js.example>]
-
-
-API
----
-
 '''
 
 from __future__ import print_function

--- a/heron_wsgi/admin_lib/mockDirectory.csv
+++ b/heron_wsgi/admin_lib/mockDirectory.csv
@@ -9,3 +9,4 @@ Koam,koam.rin,Rin,,Student,Undergrad,0,N,
 Maker,trouble.maker,Trouble,tmaker@not.js.example,Trouble1956,Somewhere,0,Y,2020-01-01
 User,act.user,Act,act.user@js.example,Student,Undergrad,0,N,2020-01-01
 ryan,todd.ryan,todd,,Chair of Emailing,theInternet,1234,Y,2012-01-01
+smith,js123,james,j12s34@kumc.edu,Chair of Neurology,Neurology,1234,Y,2012-01-01


### PR DESCRIPTION
this causes heron-admin to attempt to find a user by `uid`@kumc.edu if the given `uid` is not found.

this is useful, for example, if a sponsorship request or a study team is created with someone's alternate uid as it shows up in their email address.