### PR TITLE
#6562 fix broken human subject training link

### DIFF
--- a/heron_wsgi/templates/index.html
+++ b/heron_wsgi/templates/index.html
@@ -235,7 +235,7 @@
         <label>
           <input type="checkbox" disabled="disabled" py:attrs="trainingCurrent" />
         <a
-        href="http://www2.kumc.edu/researchcompliance/human_subjects_tutorial_inst.htm"
+        href="https://kumed.sharepoint.com/sites/mykumc/compliance/Pages/CITI-Training-FAQs.aspx"
         >Human subjects training</a> is complete and current?</label>
           <a py:if="not trainingCurrent" href="#training-records">*</a>
       </li>


### PR DESCRIPTION
Ari requested a fix to broken human subject training link. Needs updated to ​https://kumed.sharepoint.com/sites/mykumc/compliance/Pages/CITI-Training-FAQs.aspx