### PR TITLE
#6562 start Heron_tricol_01 picture and starting paragraph on the same line

### DIFF
--- a/heron_wsgi/templates/index.html
+++ b/heron_wsgi/templates/index.html
@@ -118,8 +118,8 @@
 		<li>Vizient (Quality Measure Data - formerly University HealthSystem Consortium)</li> 
 	</ul>
   </td>
-  <td align = "center" valign = "center">
-  <br /><img src="av/220px-Heron_tricol_01.JPG" alt="" />
+  <td align = "center" valign = "top">
+  <img src="av/220px-Heron_tricol_01.JPG" alt="" />
   <br /><small>photo credit:
   <a href="https://commons.wikimedia.org/wiki/User:Chrharshaw" title = "wikimedia"
      >Christopher Harshaw</a></small>


### PR DESCRIPTION
Ari stated that the paragraph text starts a line above where the picture starts. She requested she did like the picture to be approximately the same size as the paragraph and for them to start on the same line. However will try to make the image start the same line with the paragraph but cannot make the picture the same height with paragraph This is because the image is of fixed width and height `[220px × 181px] `and will require the font size for words on the page to change.