### PR TITLE
#6562 remove ACT Sponsorship link from homepage

### DIFF
--- a/heron_wsgi/templates/index.html
+++ b/heron_wsgi/templates/index.html
@@ -57,8 +57,6 @@
     </li>
     <li><a href="${data_use_path}">HERON Data Use or Recruitment Request</a>
     </li>
-    <li><a href="${act_sponsorship_path}">ACT SHRINE Sponsorship Request</a>
-    </li>
     <li><a href="${greenheron_use_path}">Green HERON Sponsorship or Data Use Request</a>
     </li>
   </ul>


### PR DESCRIPTION
Remove ACT Sponsorship link from homepage. Per @schandaka we are not adding new users.